### PR TITLE
Add a feature to display a modal pop-up 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,25 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
+    <!-- link css file -->
     <link rel="stylesheet" href="main.css">
 </head>
 <body>
+    <!-- title page -->
     <div >
         <h1>List Lastest Tutorials</h1>
     </div>
+    <!-- div contain list  -->
     <div id="content"></div>
-    <!-- <button id="test"></button> -->
+    <!-- dialog modal  -->
     <dialog id="modal"> 
+        <!-- message modal  -->
         <div id="modal-title"><p>Are you sure you want to go this page</p></div>
+        <!-- modal button  -->
         <div id="modal-button">
+            <!-- no button use to close modal  -->
             <div id="no-button"><a id="no-button-a">No</a></div>
+            <!-- yes button use to go to SESV webpage  -->
             <div id="yes-button"><a id="yes-button-a">Yes</a></div>
         </div>
     </dialog>

--- a/index.html
+++ b/index.html
@@ -6,26 +6,34 @@
     <title>Document</title>
     <!-- link css file -->
     <link rel="stylesheet" href="main.css">
+    
 </head>
 <body>
     <!-- title page -->
     <div >
         <h1>List Lastest Tutorials</h1>
     </div>
+    
     <!-- div contain list  -->
     <div id="content"></div>
+    
     <!-- dialog modal  -->
     <dialog id="modal"> 
+        
         <!-- message modal  -->
         <div id="modal-title"><p>Are you sure you want to go this page</p></div>
+        
         <!-- modal button  -->
         <div id="modal-button">
+            
             <!-- no button use to close modal  -->
             <div id="no-button"><a id="no-button-a">No</a></div>
+            
             <!-- yes button use to go to SESV webpage  -->
             <div id="yes-button"><a id="yes-button-a">Yes</a></div>
         </div>
     </dialog>
+
     <!-- link script file -->
     <script src="main.js"></script>
 </body>

--- a/main.css
+++ b/main.css
@@ -9,15 +9,14 @@ body{
     width: 100%;
     background-attachment: fixed;
 }
+
 div{
     width: 50%;
     text-align: center;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    /* position: fixed; */
 }
 
 #content {
-    /* width: 100%; */
     height: auto;
     display: flex;
     flex-direction: column;
@@ -26,11 +25,11 @@ div{
 #lession-title {
     background-color: black;
     opacity: 50%;
-    border: 2px solid black;
-    border-radius: 20px;
-    font-size: 20px;
+    border: 0.125rem solid black; 
+    border-radius: 1.25rem; 
+    font-size: 1.25rem; 
     text-decoration: none;
-    margin: 10px 0px 10px 0px;
+    margin: 0.625rem 0;
     color: white;
     padding: 0;
     text-align: center;
@@ -38,16 +37,16 @@ div{
     cursor: pointer;
 }
 
-#modal{
-    border: 0px;
-    border-radius: 20px;
+#modal {
+    border: 0;
+    border-radius: 1.25rem;
     padding: 0;
-    font-size: 20px;
-    width: 20rem;
-    height: 10rem;
+    font-size: 1.25rem;
+    width: 20rem; 
+    height: 9.375rem; 
 }
 
-#modal-title{
+#modal-title {
     width: 100%;
     height: 50%;
     display: flex;
@@ -55,18 +54,18 @@ div{
     align-items: center;
 }
 
-#modal-title p{
-    margin: 0px 10px 0px 10px;
+#modal-title p {
+    margin: 0 0.625rem;
 }
 
-#modal-button{
+#modal-button {
     display: flex;
     flex-direction: row;
     width: 100%;
     height: 50%;
 }
 
-#yes-button{
+#yes-button {
     width: 50%;
     text-align: center;
     text-decoration: none;
@@ -77,12 +76,12 @@ div{
     cursor: pointer;
 }
 
-#yes-button-a{
+#yes-button-a {
     text-decoration: none;
     color: white;
 }
 
-#no-button{
+#no-button {
     width: 50%;
     text-align: center;
     cursor: pointer;

--- a/main.css
+++ b/main.css
@@ -42,7 +42,8 @@ div{
     border: 0px;
     border-radius: 20px;
     padding: 0;
-    width: 400px;
+    font-size: 20px;
+    width: 20rem;
     height: 150px;
 }
 

--- a/main.css
+++ b/main.css
@@ -3,7 +3,7 @@ body{
     padding: 0;
     display: flex;
     flex-direction: row;
-    background-image: url(/aaron-burden-6jYoil2GhVk-unsplash.jpg);
+    background-image: url(./aaron-burden-6jYoil2GhVk-unsplash.jpg);
     background-size: 100%;
     position: 0;
     width: 100%;

--- a/main.css
+++ b/main.css
@@ -3,7 +3,7 @@ body{
     padding: 0;
     display: flex;
     flex-direction: row;
-    background-image: url(./aaron-burden-6jYoil2GhVk-unsplash.jpg);
+    background-image: url("./aaron-burden-6jYoil2GhVk-unsplash.jpg");
     background-size: 100%;
     position: 0;
     width: 100%;
@@ -44,7 +44,7 @@ div{
     padding: 0;
     font-size: 20px;
     width: 20rem;
-    height: 150px;
+    height: 10rem;
 }
 
 #modal-title{

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@
 const getLatestTutorials = async () => {
     //fetch API
   let response = await fetch(
-    "https://www.sesvtutorial.com/page-data/tutorials/page-data.json"
+    "https://mocki.io/v1/2f27ece2-ff49-4c13-bba1-3901e2a29c99" //fake API JSON
   );
   //convert resp to Object
   let resultObject = await response.json();

--- a/main.js
+++ b/main.js
@@ -8,12 +8,10 @@
 //output: the list display in screen
 const getLatestTutorials = async () => {
     //1/fetch API
-    //The original API is https://www.sesvtutorial.com/page-data/tutorials/page-data.json. Fetch it return a CORS error., there are two ways to fix this:
+    //The original API is https://www.sesvtutorial.com/page-data/tutorials/page-data.json. Fetch it return a CORS error because missing Access-Control-Allow-Origin Header from the origin Server, there are two ways to fix this:
     //    1. Disabling CORS on the client-side, but this is very inconvenient because not everyone wants to disable it.
     //    2. Fixing it on the server-side. However, since this API belongs to SESV, I don't have the permissions to modify the server.
-    // Therefore, I created a fake server to fetch SESV data(Servers are not bound by CORS (CORS is just a security measure applied by browsers to protect users, and only browsers follow CORS). Therefore, from another server, we can fetch the API and configure 
-    // the fake server to set the Access-Control-Allow-Origin header so that the browser can proceed.) 
-    // and fetch the data back from this fake server to resolve the CORS issue.
+    // Therefore, I created a fake server to fetch SESV data(Servers are not bound by CORS (CORS is just a security measure applied by browsers to protect users, and only browsers follow CORS). Therefore, from another server, we can fetch the API and configure the fake server to set the Access-Control-Allow-Origin header so that the browser can proceed.) and fetch the data back from this fake server to resolve the CORS issue.
   let response = await fetch(
     "https://mocki.io/v1/2f27ece2-ff49-4c13-bba1-3901e2a29c99" //fake API JSON
   );

--- a/main.js
+++ b/main.js
@@ -7,15 +7,22 @@
 //- call display func
 //output: the list display in screen
 const getLatestTutorials = async () => {
-    //fetch API
+    //1/fetch API
+    //The original API is https://www.sesvtutorial.com/page-data/tutorials/page-data.json. Since fetching this API using the Fetch API causes a CORS error, there are two ways to fix this:
+    //    1. Disabling CORS on the client-side, but this is very inconvenient because not everyone wants to disable it.
+    //    2. Fixing it on the server-side. However, since this API belongs to SESV, I don't have the permissions to modify the server.
+    //Therefore, I created a fake server to fetch SESV data and fetch the data back from this fake server to resolve the CORS issue.
   let response = await fetch(
     "https://mocki.io/v1/2f27ece2-ff49-4c13-bba1-3901e2a29c99" //fake API JSON
   );
-  //convert resp to Object
+    
+  //2/convert resp to Object
   let resultObject = await response.json();
-  //get data latest tutorials of Object
+    
+  //3/get data latest tutorials of Object
   let dataTutorials = resultObject["result"]["data"]["posts"]["edges"];
-  //call display func
+    
+  //4/call display func
   displayLatestTutorials(dataTutorials);
 };
 

--- a/main.js
+++ b/main.js
@@ -8,10 +8,12 @@
 //output: the list display in screen
 const getLatestTutorials = async () => {
     //1/fetch API
-    //The original API is https://www.sesvtutorial.com/page-data/tutorials/page-data.json. Since fetching this API using the Fetch API causes a CORS error, there are two ways to fix this:
+    //The original API is https://www.sesvtutorial.com/page-data/tutorials/page-data.json. Fetch it return a CORS error., there are two ways to fix this:
     //    1. Disabling CORS on the client-side, but this is very inconvenient because not everyone wants to disable it.
     //    2. Fixing it on the server-side. However, since this API belongs to SESV, I don't have the permissions to modify the server.
-    //Therefore, I created a fake server to fetch SESV data and fetch the data back from this fake server to resolve the CORS issue.
+    // Therefore, I created a fake server to fetch SESV data(Servers are not bound by CORS (CORS is just a security measure applied by browsers to protect users, and only browsers follow CORS). Therefore, from another server, we can fetch the API and configure 
+    // the fake server to set the Access-Control-Allow-Origin header so that the browser can proceed.) 
+    // and fetch the data back from this fake server to resolve the CORS issue.
   let response = await fetch(
     "https://mocki.io/v1/2f27ece2-ff49-4c13-bba1-3901e2a29c99" //fake API JSON
   );

--- a/main.js
+++ b/main.js
@@ -48,6 +48,7 @@ const displayLatestTutorials = (dataTutorials) => {
           );
           //set no button if user choose then close modal
           document.getElementById("no-button").addEventListener('click',()=>{
+            //close modal pop-up
             modal.close();
           })
         })

--- a/main.js
+++ b/main.js
@@ -28,26 +28,34 @@ const getLatestTutorials = async () => {
 //-appendChild Node to div content 
 //output: the list display in screen
 const displayLatestTutorials = (dataTutorials) => {
+
     dataTutorials.forEach((element) => {
-        //create anchor element to contain link and title
+
+        //1. create anchor element to contain link and title
         let titleElement = document.createElement("a");
         let modal = document.getElementById("modal")
-        //set attribute id = lession-title to use css
+
+        //2.set attribute id = lession-title to use css
         titleElement.setAttribute("id", "lession-title");
-        //inner text to anchor
+
+        //3. inner text to anchor
         titleElement.innerText = `${element["node"]["frontmatter"]["title"]}`;
         
-        //add event show modal to titleElement
+        //4. add event show modal to titleElement
         titleElement.addEventListener('click',()=>{
-          //if click point at titleElement then show modal
+
+          //5. if click point at titleElement then show modal
           modal.showModal();
-          //set yes button if user choose then go to SESV lession
+
+          //6. set yes button if user choose then go to SESV lession
           document.getElementById("yes-button-a").setAttribute(
             "href",
             `https://www.sesvtutorial.com${element["node"]["fields"]["slug"]}`
           );
-          //set no button if user choose then close modal
+
+          //7. set no button if user choose then close modal
           document.getElementById("no-button").addEventListener('click',()=>{
+
             //close modal pop-up
             modal.close();
           })


### PR DESCRIPTION
**Update new API and add a feature to display a modal pop-up to confirm if the user wants to proceed to that webpage.**

The original API is `https://www.sesvtutorial.com/page-data/tutorials/page-data.json`. Since fetching this API using the Fetch API causes a CORS error, there are two ways to fix this: 
1. Disabling CORS on the client-side, but this is very inconvenient because not everyone wants to disable it.  
2. Fixing it on the server-side. However, since this API belongs to SESV, I don't have the permissions to modify the server.

Therefore, I created a fake server to fetch SESV data and fetch the data back from this fake server to resolve the CORS issue.

**Process:**
- I have researched and created a dialog with a basic interface like a gif, featuring two buttons: Yes and No.
- I added an event where, if a user clicks on the lesson title, a modal will appear to confirm whether to proceed or stay.
- If the Yes button is clicked, the `href` attribute is set to the URL of the SESV lesson.
- If the No button is clicked, the modal will close.

![Document - Google Chrome 2024-09-27 23-05-54](https://github.com/user-attachments/assets/725981bb-d065-4358-8529-a095773250b2)

PR checklist:

- [x] CS1: correct, simple and short
- [x] CS2: security vulnerabilities have been considered and prevented
- [x] CS3: optimized time, space code complexity and network bandwidth
- [x] CS4: Added unit tests with 80% - 100% code coverage
- [x] CS5.1: Variables and functions naming are semantic and easy to understand
- [x] CS5.2: Documented code followed by [IPO rules](https://www.sesvtutorial.com/setting-up-your-study-environment-and-mentality/#input---process---output-ipo), step by step comment code to record your solution.
- [x] CS6: Elegant code: are you proud of this PR? Does it make the code base a better place?
- [ ] Updated Postman collection (if any)
- [ ] Added new `environment variable`, `serviceKeys` to `.env_example` file and `github secrets` (if any)
- [x] Deployed on `development` server and confirmed working

After PR merged:

- [ ] Checked your changes on `main` and confirmed working
